### PR TITLE
feat: use typo3 core YamlFileLoader

### DIFF
--- a/Tests/Unit/Configuration/ConfigurationFinderTest.php
+++ b/Tests/Unit/Configuration/ConfigurationFinderTest.php
@@ -17,14 +17,34 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Core\Configuration\ConfigurationManager;
+use TYPO3\CMS\Core\Configuration\Loader\YamlFileLoader;
 use TYPO3\CMS\Core\Core\ApplicationContext;
 use TYPO3\CMS\Core\Core\Environment;
+use TYPO3\CMS\Core\Log\Logger;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 #[CoversClass(ConfigurationFinder::class)]
 #[RunTestsInSeparateProcesses]
 final class ConfigurationFinderTest extends TestCase
 {
     private static string $configPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $configurationManager = new ConfigurationManager();
+        $GLOBALS['TYPO3_CONF_VARS'] = $configurationManager->getDefaultConfiguration();
+
+        GeneralUtility::addInstance(
+            YamlFileLoader::class,
+            GeneralUtility::makeInstance(
+                YamlFileLoader::class,
+                $this->createMock(Logger::class),
+            ),
+        );
+    }
 
     public static function setUpBeforeClass(): void
     {


### PR DESCRIPTION
This way imports in sites config yaml files are processed.

Also extra code for parsing and processing of env vars (%env(MY_ENV)%) is removed, while already implemented by YamlFileLoader.

All tests and qa done and succeed for T3 v12 + v13.3.

Background
Usually our config/sites/*/config.yaml import application context dependent configuration:

    imports:
      - { resource: 'Context/%env(TYPO3_CONTEXT)%/config.yaml' }

Contexts (e.g. Production, Staging, Development) can have different values for matomoWidgets* settings (mostly matomoWidgetsUrl and matomoWidgetsIdSite).
The previously used Symfony Yaml Parser didn't processed imports.